### PR TITLE
Spain changes

### DIFF
--- a/sql/base.sql
+++ b/sql/base.sql
@@ -562,6 +562,25 @@ INSERT OR IGNORE INTO ModifierArguments (ModifierId , Name , Value)
 --==================
 -- Spain
 --==================
+-- missions get +1 housing on home continent
+INSERT OR IGNORE INTO Requirements (RequirementId, RequirementType) VALUES
+	('REQUIRES_PLOT_IS_OWNER_CAPITAL_CONTINENT_BBG', 'REQUIREMENT_PLOT_IS_OWNER_CAPITAL_CONTINENT');
+INSERT OR IGNORE INTO RequirementSets VALUES
+	('PLOT_CAPITAL_CONTINENT_REQUIREMENTS_BBG', 'REQUIREMENTSET_TEST_ALL');
+INSERT OR IGNORE INTO RequirementSetRequirements VALUES
+	('PLOT_CAPITAL_CONTINENT_REQUIREMENTS_BBG', 'REQUIRES_PLOT_IS_OWNER_CAPITAL_CONTINENT_BBG');
+INSERT OR IGNORE INTO Modifiers (ModifierId , ModifierType , SubjectRequirementSetId)
+	VALUES ('MISSION_HOMECONTINENT_HOUSING_BBG' , 'MODIFIER_SINGLE_CITY_ADJUST_IMPROVEMENT_HOUSING', 'PLOT_CAPITAL_CONTINENT_REQUIREMENTS_BBG');
+INSERT OR IGNORE INTO ModifierArguments (ModifierId , Name , Value)
+	VALUES ('MISSION_HOMECONTINENT_HOUSING_BBG' , 'Amount' , 1);
+INSERT OR IGNORE INTO ImprovementModifiers (ImprovementType , ModifierId)
+	VALUES ('IMPROVEMENT_MISSION' , 'MISSION_HOMECONTINENT_HOUSING_BBG');
+-- Missions cannot be placed next to each other
+UPDATE Improvements SET SameAdjacentValid=0 WHERE ImprovementType='IMPROVEMENT_MISSION';
+-- Missions moved to Theology
+UPDATE Improvements SET PrereqCivic='CIVIC_THEOLOGY' WHERE ImprovementType='IMPROVEMENT_MISSION';
+-- Missions get bonus science at Enlightenment instead of cultural heritage
+UPDATE Improvement_BonusYieldChanges SET PrereqCivic='CIVIC_THE_ENLIGHTENMENT' WHERE Id='17';
 
 --Remove free Builder on other continents
 DELETE FROM TraitModifiers WHERE TraitType = 'TRAIT_CIVILIZATION_TREASURE_FLEET' AND ModifierId = 'TRAIT_INTERCONTINENTAL_BUILDER';

--- a/sql/base.sql
+++ b/sql/base.sql
@@ -654,6 +654,38 @@ INSERT OR IGNORE INTO Improvement_BonusYieldChanges (ImprovementType, YieldType,
 	('IMPROVEMENT_ZIGGURAT', 'YIELD_SCIENCE', 1, 'CIVIC_THE_ENLIGHTENMENT');
 
 
+-- Can make Fleets with a shipyard. +25% prod towards fleets/armadas with shipyard
+INSERT INTO Modifiers(ModifierId, ModifierType, OwnerRequirementSetId) 
+	VALUES
+    	('BBG_SPAIN_FLEET_DISCOUNT', 'MODIFIER_CITY_CORPS_ARMY_ADJUST_DISCOUNT', 'BBG_PLAYER_IS_SPAIN');
+
+INSERT INTO ModifierArguments(ModifierId, Name, Value) 
+	VALUES
+    	('BBG_SPAIN_FLEET_DISCOUNT', 'UnitDomain', 'DOMAIN_SEA'),
+    	('BBG_SPAIN_FLEET_DISCOUNT', 'Amount', '25');
+
+INSERT INTO BuildingModifiers(BuildingType, ModifierId) 
+	VALUES
+    	('BUILDING_SHIPYARD', 'BBG_SPAIN_FLEET_DISCOUNT');
+    	
+    -- Spain requirement
+INSERT OR IGNORE INTO RequirementSets(RequirementSetId , RequirementSetType) 
+	VALUES
+	('BBG_PLAYER_IS_SPAIN', 'REQUIREMENTSET_TEST_ANY');
+
+INSERT OR IGNORE INTO RequirementSetRequirements(RequirementSetId , RequirementId) 
+	VALUES
+	('BBG_PLAYER_IS_SPAIN', 'BBG_PLAYER_IS_SPAIN_REQUIREMENT');
+
+INSERT OR IGNORE INTO Requirements(RequirementId , RequirementType) 
+	VALUES
+	('BBG_PLAYER_IS_SPAIN_REQUIREMENT' , 'REQUIREMENT_PLAYER_TYPE_MATCHES');
+
+INSERT OR IGNORE INTO RequirementArguments(RequirementId , Name, Value) 
+	VALUES
+	('BBG_PLAYER_IS_SPAIN_REQUIREMENT' , 'CivilizationType', 'CIVILIZATION_SPAIN');
+
+
 
 --==============================================================
 --******				B U I L D I N G S			  	  ******


### PR DESCRIPTION
   - missionaries required to be on tile with conquistador (still 30% discount on missionary purchase)
   - instead of 3x yields for trade routes on diff continents, make 2x
   - keep continent split bias
   - remove free builder for cities on diff continent
   - early fleets at mercenaries (was like this previously)
   - earl armadas at mercantilism (firaxis buff, was mobilization)