### PR TITLE
[NEW CIVIC] Pathfinder

### DIFF
--- a/sql/base.sql
+++ b/sql/base.sql
@@ -1302,6 +1302,18 @@ INSERT INTO RequirementArguments
 --==============================================================
 --******			P O L I C Y   C A R D S				  ******
 --==============================================================
+-- Pathfinder [New Civic] => +50% production to recon units at Mercenaries
+INSERT INTO Types (Types, Kind) Values ('POLICY_PATHFINDER', 'KIND_POLICY');
+INSERT INTO Policies (PolicyType, Name, Description, PrereqCivic, GovernmentSlotType)
+	Values('POLICY_PATHFINDER', 'LOC_POLICY_PATHFINDER_NAME', 'LOC_POLICY_PATHFINDER_DESCRIPTION', 'CIVIC_MERCENARIES', 'SLOT_MILITARY');
+UPDATE ObsoletePolicies (PolicyType, ObsoletePolicy) Values ('POLICY_SURVEY', 'POLICY_PATHFINDER');
+INSERT INTO PolicyModifiers (PolicyType, ModifierId) Values ('POLICY_PATHFINDER', 'PATHFINDER_RECON_UNIT_PRODUCTION');
+INSERT INTO Modifiers (ModifierId, ModifierType) Values ('PATHFINDER_RECON_UNIT_PRODUCTION', 'MODIFIER_PLAYER_CITIES_ADJUST_UNIT_TAG_ERA_PRODUCTION');
+INSERT INTO ModifierArguments (ModifierId, Name, Value, Extra)
+	Values ('PATHFINDER_RECON_UNIT_PRODUCTION', UnitPromotionClass, PROMOTION_CLASS_RECON, -1),
+		('PATHFINDER_RECON_UNIT_PRODUCTION', 'EraType', 'ERA_MEDIEVAL', -1 ),
+		('PATHFINDER_RECON_UNIT_PRODUCTION', 'Amount', 50, -1);
+
 -- destroy barbs
 UPDATE ModifierArguments SET Value='10' WHERE ModifierId='DISCIPLINE_BARBARIANCOMBAT';
 -- add 3 siege policy cards


### PR DESCRIPTION
Added a new MERCENARIES Policy card named Pathfinder that gives 50% production toward Recon Units
Survey is obsolete with this card and Pathfinder has not obsolete civic or card (this may need to be changed)

In response to Fish's suggested changes